### PR TITLE
Add shared library and cmake support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,10 @@ compiler:
   - clang
   - gcc
 
+addons:
+  apt:
+    packages:
+      - cmake
+
 script: make
+script: mkdir build && cd build && cmake -DWITH_EXAMPLES=ON .. && make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 2.8)
+
+project (genann)
+set(CMAKE_BUILD_TYPE Release)
+
+include_directories(.)
+add_library(genann SHARED genann.c)
+target_link_libraries(genann m)
+
+OPTION(WITH_EXAMPLES "Also build examples" OFF) # Enabled by default
+
+IF(WITH_EXAMPLES)
+    add_executable(example1 example1.c)
+    target_link_libraries(example1 genann)
+    add_executable(example2 example2.c)
+    target_link_libraries(example2 genann)
+    add_executable(example3 example3.c)
+    target_link_libraries(example3 genann)
+    add_executable(example4 example4.c)
+    target_link_libraries(example4 genann)
+ENDIF(WITH_EXAMPLES)
+
+install (TARGETS genann
+         ARCHIVE DESTINATION lib
+         LIBRARY DESTINATION lib
+         RUNTIME DESTINATION bin)
+
+### Debian Package generation
+set(CPACK_GENERATOR "DEB")
+set(CPACK_PACKAGE_VERSION "0.1.0")
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "https://github.com/codeplea/genann")
+include(CPack)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ functions and little extra.
 
 Genann is self-contained in two files: `genann.c` and `genann.h`. To use Genann, simply add those two files to your project.
 
+Genann now also can be built as shared library using cmake. You can simply build it with:
+
+```Shell
+mkdir build
+cd build
+cmake -DWITH_EXAMPLES=ON .. && make
+```
+
+It is also possible to build a Debian package using:
+make package
+
 ## Example Code
 
 Four example programs are included with the source code.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ cmake -DWITH_EXAMPLES=ON .. && make
 ```
 
 It is also possible to build a Debian package using:
+```Shell
 make package
+```
 
 ## Example Code
 


### PR DESCRIPTION
This PR will add the option to build genann as shared library with cmake. It is also possible to build a debian package which can be installed with dpkg. This will not break anything of the existing buildprocess!