### PR TITLE
Miscellaneous cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,6 @@ example4: example4.o genann.o
 
 
 clean:
-	rm *.o
-	rm *.exe
-	rm persist.txt
+	$(RM) *.o
+	$(RM) *.exe
+	$(RM) persist.txt

--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,22 @@
 CCFLAGS = -Wall -Wshadow -O2 -g
-LFLAGS = -lm
+LDLIBS = -lm
 
 
 all: test example1 example2 example3 example4
 
 
 test: test.o genann.o
-	$(CC) $(CCFLAGS) -o $@ $^ $(LFLAGS)
-	./$@
 
+check: test
+	./$^
 
 example1: example1.o genann.o
-	$(CC) $(CCFLAGS) -o $@ $^ $(LFLAGS)
 
 example2: example2.o genann.o
-	$(CC) $(CCFLAGS) -o $@ $^ $(LFLAGS)
 
 example3: example3.o genann.o
-	$(CC) $(CCFLAGS) -o $@ $^ $(LFLAGS)
 
 example4: example4.o genann.o
-	$(CC) $(CCFLAGS) -o $@ $^ $(LFLAGS)
-
-.c.o:
-	$(CC) -c $(CCFLAGS) $< -o $@
 
 
 clean:

--- a/example4.c
+++ b/example4.c
@@ -42,7 +42,10 @@ void load_data() {
         double *c = class + i * 3;
         c[0] = c[1] = c[2] = 0.0;
 
-        fgets(line, 1024, in);
+        if (fgets(line, 1024, in) == NULL) {
+            perror("fgets");
+            exit(1);
+        }
 
         char *split = strtok(line, ",");
         for (j = 0; j < 4; ++j) {

--- a/genann.c
+++ b/genann.c
@@ -25,12 +25,12 @@
 
 #include "genann.h"
 
+#include <assert.h>
+#include <errno.h>
+#include <math.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <math.h>
-#include <assert.h>
-#include <stdio.h>
-#include <errno.h>
 
 #define LOOKUP_SIZE 4096
 

--- a/genann.c
+++ b/genann.c
@@ -30,6 +30,7 @@
 #include <math.h>
 #include <assert.h>
 #include <stdio.h>
+#include <errno.h>
 
 #define LOOKUP_SIZE 4096
 
@@ -122,13 +123,27 @@ genann *genann_init(int inputs, int hidden_layers, int hidden, int outputs) {
 
 genann *genann_read(FILE *in) {
     int inputs, hidden_layers, hidden, outputs;
-    fscanf(in, "%d %d %d %d", &inputs, &hidden_layers, &hidden, &outputs);
+    int rc;
+
+    errno = 0;
+    rc = fscanf(in, "%d %d %d %d", &inputs, &hidden_layers, &hidden, &outputs);
+    if (rc < 4 || errno != 0) {
+        perror("fscanf");
+        return NULL;
+    }
 
     genann *ann = genann_init(inputs, hidden_layers, hidden, outputs);
 
     int i;
     for (i = 0; i < ann->total_weights; ++i) {
-        fscanf(in, " %le", ann->weight + i);
+        errno = 0;
+        rc = fscanf(in, " %le", ann->weight + i);
+        if (rc < 1 || errno != 0) {
+            perror("fscanf");
+            genann_free(ann);
+
+            return NULL;
+        }
     }
 
     return ann;


### PR DESCRIPTION
Fix unused-result warnings from gcc-6.3, errors in clean target on cleaning artefacts that don't exist, sort header order.