### PR TITLE
RFC: Increase genann performance by roughly 30%

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CCFLAGS = -Wall -Wshadow -O2 -g
+CFLAGS = -Wall -Wshadow -O2 -g
 LDLIBS = -lm
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,7 @@
 CFLAGS = -Wall -Wshadow -O2 -g
 LDLIBS = -lm
 
-
 all: test example1 example2 example3 example4
-
 
 test: test.o genann.o
 
@@ -21,5 +19,5 @@ example4: example4.o genann.o
 
 clean:
 	$(RM) *.o
-	$(RM) *.exe
+	$(RM) test example1 example2 example3 example4 *.exe
 	$(RM) persist.txt

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS = -Wall -Wshadow -O2 -g
+CFLAGS = -Wall -Wshadow -O3 -g -march=native
 LDLIBS = -lm
 
 all: test example1 example2 example3 example4

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,15 @@ LDLIBS = -lm
 
 all: test example1 example2 example3 example4
 
+sigmoid: CFLAGS += -Dgenann_act=genann_act_sigmoid_cached
+sigmoid: all
+
+threshold: CFLAGS += -Dgenann_act=genann_act_threshold
+threshold: all
+
+linear: CFLAGS += -Dgenann_act=genann_act_linear
+linear: all
+
 test: test.o genann.o
 
 check: test
@@ -21,3 +30,5 @@ clean:
 	$(RM) *.o
 	$(RM) test example1 example2 example3 example4 *.exe
 	$(RM) persist.txt
+
+.PHONY: sigmoid threshold linear clean

--- a/genann.c
+++ b/genann.c
@@ -32,61 +32,71 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifndef genann_act
+#define genann_act_hidden genann_act_hidden_indirect
+#define genann_act_output genann_act_output_indirect
+#else
+#define genann_act_hidden genann_act
+#define genann_act_output genann_act
+#endif
+
 #define LOOKUP_SIZE 4096
 
-double genann_act_sigmoid(double a) {
+double genann_act_hidden_indirect(const struct genann *ann, double a) {
+    return ann->activation_hidden(ann, a);
+}
+
+double genann_act_output_indirect(const struct genann *ann, double a) {
+    return ann->activation_output(ann, a);
+}
+
+const double sigmoid_dom_min = -15.0;
+const double sigmoid_dom_max = 15.0;
+double interval;
+double lookup[LOOKUP_SIZE];
+
+#define likely(x)       __builtin_expect(!!(x), 1)
+#define unlikely(x)     __builtin_expect(!!(x), 0)
+#define __unused        __attribute__((unused))
+
+double inline genann_act_sigmoid(const genann *ann __unused, double a) {
     if (a < -45.0) return 0;
     if (a > 45.0) return 1;
     return 1.0 / (1 + exp(-a));
 }
 
-
-double genann_act_sigmoid_cached(double a) {
-    /* If you're optimizing for memory usage, just
-     * delete this entire function and replace references
-     * of genann_act_sigmoid_cached to genann_act_sigmoid
-     */
-    const double min = -15.0;
-    const double max = 15.0;
-    static double interval;
-    static int initialized = 0;
-    static double lookup[LOOKUP_SIZE];
-
-    /* Calculate entire lookup table on first run. */
-    if (!initialized) {
-        const double f = (max - min) / LOOKUP_SIZE;
+void genann_init_sigmoid_lookup(const genann *ann) {
+        const double f = (sigmoid_dom_max - sigmoid_dom_min) / LOOKUP_SIZE;
         int i;
-        interval = LOOKUP_SIZE / (max - min);
-        for (i = 0; i < LOOKUP_SIZE; ++i) {
-            lookup[i] = genann_act_sigmoid(min + f * i);
-        }
-        /* This is down here to make this thread safe. */
-        initialized = 1;
-    }
 
+        interval = LOOKUP_SIZE / (sigmoid_dom_max - sigmoid_dom_min);
+        for (i = 0; i < LOOKUP_SIZE; ++i) {
+            lookup[i] = genann_act_sigmoid(ann, sigmoid_dom_min + f * i);
+        }
+}
+
+double inline genann_act_sigmoid_cached(const genann *ann __unused, double a) {
     assert(!isnan(a));
 
-    if (a < min) return lookup[0];
-    if (a >= max) return lookup[LOOKUP_SIZE - 1];
+    if (a < sigmoid_dom_min) return lookup[0];
+    if (a >= sigmoid_dom_max) return lookup[LOOKUP_SIZE - 1];
 
-    size_t j = (size_t)((a-min)*interval+0.5);
+    size_t j = (size_t)((a-sigmoid_dom_min)*interval+0.5);
 
-    if (j < 0) return lookup[0];
-    if (j >= LOOKUP_SIZE) return lookup[LOOKUP_SIZE - 1];
+    /* Because floating point... */
+    if (unlikely(j < 0)) return lookup[0];
+    if (unlikely(j >= LOOKUP_SIZE)) return lookup[LOOKUP_SIZE - 1];
 
     return lookup[j];
 }
 
-
-double genann_act_threshold(double a) {
-    return a > 0;
-}
-
-
-double genann_act_linear(double a) {
+double inline genann_act_linear(const struct genann *ann __unused, double a) {
     return a;
 }
 
+double inline genann_act_threshold(const struct genann *ann __unused, double a) {
+    return a > 0;
+}
 
 genann *genann_init(int inputs, int hidden_layers, int hidden, int outputs) {
     if (hidden_layers < 0) return 0;
@@ -123,6 +133,8 @@ genann *genann_init(int inputs, int hidden_layers, int hidden, int outputs) {
 
     ret->activation_hidden = genann_act_sigmoid_cached;
     ret->activation_output = genann_act_sigmoid_cached;
+
+    genann_init_sigmoid_lookup(ret);
 
     return ret;
 }
@@ -200,9 +212,6 @@ double const *genann_run(genann const *ann, double const *inputs) {
 
     int h, j, k;
 
-    const genann_actfun act = ann->activation_hidden;
-    const genann_actfun acto = ann->activation_output;
-
     if (!ann->hidden_layers) {
         double *ret = o;
         for (j = 0; j < ann->outputs; ++j) {
@@ -210,7 +219,7 @@ double const *genann_run(genann const *ann, double const *inputs) {
             for (k = 0; k < ann->inputs; ++k) {
                 sum += *w++ * i[k];
             }
-            *o++ = acto(sum);
+            *o++ = genann_act_output(ann, sum);
         }
 
         return ret;
@@ -222,7 +231,7 @@ double const *genann_run(genann const *ann, double const *inputs) {
         for (k = 0; k < ann->inputs; ++k) {
             sum += *w++ * i[k];
         }
-        *o++ = act(sum);
+        *o++ = genann_act_hidden(ann, sum);
     }
 
     i += ann->inputs;
@@ -234,7 +243,7 @@ double const *genann_run(genann const *ann, double const *inputs) {
             for (k = 0; k < ann->hidden; ++k) {
                 sum += *w++ * i[k];
             }
-            *o++ = act(sum);
+            *o++ = genann_act_hidden(ann, sum);
         }
 
         i += ann->hidden;
@@ -248,7 +257,7 @@ double const *genann_run(genann const *ann, double const *inputs) {
         for (k = 0; k < ann->hidden; ++k) {
             sum += *w++ * i[k];
         }
-        *o++ = acto(sum);
+        *o++ = genann_act_output(ann, sum);
     }
 
     /* Sanity check that we used all weights and wrote all outputs. */
@@ -273,7 +282,8 @@ void genann_train(genann const *ann, double const *inputs, double const *desired
 
 
         /* Set output layer deltas. */
-        if (ann->activation_output == genann_act_linear) {
+        if (genann_act_output == genann_act_linear ||
+                ann->activation_output == genann_act_linear) {
             for (j = 0; j < ann->outputs; ++j) {
                 *d++ = *t++ - *o++;
             }

--- a/genann.c
+++ b/genann.c
@@ -344,12 +344,9 @@ void genann_train(genann const *ann, double const *inputs, double const *desired
 
         /* Set output layer weights. */
         for (j = 0; j < ann->outputs; ++j) {
-            for (k = 0; k < (ann->hidden_layers ? ann->hidden : ann->inputs) + 1; ++k) {
-                if (k == 0) {
-                    *w++ += *d * learning_rate * -1.0;
-                } else {
-                    *w++ += *d * learning_rate * i[k-1];
-                }
+            *w++ += *d * learning_rate * -1.0;
+            for (k = 1; k < (ann->hidden_layers ? ann->hidden : ann->inputs) + 1; ++k) {
+                *w++ += *d * learning_rate * i[k-1];
             }
 
             ++d;
@@ -377,12 +374,9 @@ void genann_train(genann const *ann, double const *inputs, double const *desired
 
 
         for (j = 0; j < ann->hidden; ++j) {
-            for (k = 0; k < (h == 0 ? ann->inputs : ann->hidden) + 1; ++k) {
-                if (k == 0) {
-                    *w++ += *d * learning_rate * -1.0;
-                } else {
-                    *w++ += *d * learning_rate * i[k-1];
-                }
+            *w++ += *d * learning_rate * -1.0;
+            for (k = 1; k < (h == 0 ? ann->inputs : ann->hidden) + 1; ++k) {
+                *w++ += *d * learning_rate * i[k-1];
             }
             ++d;
         }

--- a/genann.c
+++ b/genann.c
@@ -203,18 +203,41 @@ double const *genann_run(genann const *ann, double const *inputs) {
     const genann_actfun act = ann->activation_hidden;
     const genann_actfun acto = ann->activation_output;
 
+    if (!ann->hidden_layers) {
+        double *ret = o;
+        for (j = 0; j < ann->outputs; ++j) {
+            double sum = *w++ * -1.0;
+            for (k = 0; k < ann->inputs; ++k) {
+                sum += *w++ * i[k];
+            }
+            *o++ = acto(sum);
+        }
+
+        return ret;
+    }
+
+    /* Figure input layer */
+    for (j = 0; j < ann->hidden; ++j) {
+        double sum = *w++ * -1.0;
+        for (k = 0; k < ann->inputs; ++k) {
+            sum += *w++ * i[k];
+        }
+        *o++ = act(sum);
+    }
+
+    i += ann->inputs;
+
     /* Figure hidden layers, if any. */
-    for (h = 0; h < ann->hidden_layers; ++h) {
+    for (h = 1; h < ann->hidden_layers; ++h) {
         for (j = 0; j < ann->hidden; ++j) {
             double sum = *w++ * -1.0;
-            for (k = 0; k < (h == 0 ? ann->inputs : ann->hidden); ++k) {
+            for (k = 0; k < ann->hidden; ++k) {
                 sum += *w++ * i[k];
             }
             *o++ = act(sum);
         }
 
-
-        i += (h == 0 ? ann->inputs : ann->hidden);
+        i += ann->hidden;
     }
 
     double const *ret = o;
@@ -222,7 +245,7 @@ double const *genann_run(genann const *ann, double const *inputs) {
     /* Figure output layer. */
     for (j = 0; j < ann->outputs; ++j) {
         double sum = *w++ * -1.0;
-        for (k = 0; k < (ann->hidden_layers ? ann->hidden : ann->inputs); ++k) {
+        for (k = 0; k < ann->hidden; ++k) {
             sum += *w++ * i[k];
         }
         *o++ = acto(sum);

--- a/genann.c
+++ b/genann.c
@@ -54,20 +54,27 @@ double genann_act_sigmoid_cached(double a) {
 
     /* Calculate entire lookup table on first run. */
     if (!initialized) {
-        interval = (max - min) / LOOKUP_SIZE;
+        const double f = (max - min) / LOOKUP_SIZE;
         int i;
+        interval = LOOKUP_SIZE / (max - min);
         for (i = 0; i < LOOKUP_SIZE; ++i) {
-            lookup[i] = genann_act_sigmoid(min + interval * i);
+            lookup[i] = genann_act_sigmoid(min + f * i);
         }
         /* This is down here to make this thread safe. */
         initialized = 1;
     }
 
-    int i;
-    i = (int)((a-min)/interval+0.5);
-    if (i <= 0) return lookup[0];
-    if (i >= LOOKUP_SIZE) return lookup[LOOKUP_SIZE-1];
-    return lookup[i];
+    assert(!isnan(a));
+
+    if (a < min) return lookup[0];
+    if (a >= max) return lookup[LOOKUP_SIZE - 1];
+
+    size_t j = (size_t)((a-min)*interval+0.5);
+
+    if (j < 0) return lookup[0];
+    if (j >= LOOKUP_SIZE) return lookup[LOOKUP_SIZE - 1];
+
+    return lookup[j];
 }
 
 

--- a/genann.h
+++ b/genann.h
@@ -39,9 +39,9 @@ extern "C" {
 #define GENANN_RANDOM() (((double)rand())/RAND_MAX)
 #endif
 
+struct genann;
 
-typedef double (*genann_actfun)(double a);
-
+typedef double (*genann_actfun)(const struct genann *ann, double a);
 
 typedef struct genann {
     /* How many inputs, outputs, and hidden neurons. */
@@ -70,8 +70,6 @@ typedef struct genann {
 
 } genann;
 
-
-
 /* Creates and returns a new ann. */
 genann *genann_init(int inputs, int hidden_layers, int hidden, int outputs);
 
@@ -96,11 +94,11 @@ void genann_train(genann const *ann, double const *inputs, double const *desired
 /* Saves the ann. */
 void genann_write(genann const *ann, FILE *out);
 
-
-double genann_act_sigmoid(double a);
-double genann_act_sigmoid_cached(double a);
-double genann_act_threshold(double a);
-double genann_act_linear(double a);
+void genann_init_sigmoid_lookup(const genann *ann);
+double genann_act_sigmoid(const genann *ann, double a);
+double genann_act_sigmoid_cached(const genann *ann, double a);
+double genann_act_threshold(const genann *ann, double a);
+double genann_act_linear(const genann *ann, double a);
 
 
 #ifdef __cplusplus

--- a/test.c
+++ b/test.c
@@ -248,7 +248,7 @@ void sigmoid() {
     const double d = .0001;
 
     while (i < max) {
-        lfequal(genann_act_sigmoid(i), genann_act_sigmoid_cached(i));
+        lfequal(genann_act_sigmoid(NULL, i), genann_act_sigmoid_cached(NULL, i));
         i += d;
     }
 }


### PR DESCRIPTION
Hello,

Not sure if these patches go in a direction you want to take genann given it has a goal of being simple, but having said that the changes aren't terribly complicated. The core concepts are:

* Increase the default optimisation level
* Rework nested loops to eliminate branches in the inner-most loops
* Allow link-time resolution of activation functions if desired (the default remains runtime-dispatch)

The 30% value comes from measuring wall-clock execution time of `example4` with `perf` from linux-tools on my Lenovo X1 Carbon Gen 3 (Intel(R) Core(TM) i7-5600U CPU @ 2.60GHz, Linux 4.13, GCC 7.2.0), using link-time resolution of the sigmoid activation function. With this configuration the runtime of `example4` reduces from ~109ms at the start of the series to ~83ms at the end. I've included bits of the `perf` output in the commit messages to demonstrate the improvements along the way.

Let me know if this kind of work interests you :)