### PR TITLE
Add Meson build support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,10 @@
+project('genann', 'c', license : 'zlib')
+
+genann_lib = static_library('genann',
+    files('genann.c'),
+    include_directories : '.')
+
+genann_dep = declare_dependency(
+    link_with : genann_lib,
+    version : meson.project_version(),
+    include_directories : '.')


### PR DESCRIPTION
I think it would help to add a `meson.build` script for Meson users. I was going to wrap your library and have it added to the WrapDB but there doesn’t seem to be any archived releases of this library.

Why?