### PR TITLE
backpropagation for (some) user-defined activation functions

### DIFF
--- a/genann.h
+++ b/genann.h
@@ -53,6 +53,11 @@ typedef struct genann {
     /* Which activation function to use for output. Default: gennann_act_sigmoid_cached*/
     genann_actfun activation_output;
 
+    /* Derivative of the activation function, expressed in terms of the function value; i.e. f'(f_inverse(y))
+     * Used for backpropagation. Default: y(1-y), corresponding to the sigmoid. */
+    genann_actfun diffexpr_activation_hidden;
+    genann_actfun diffexpr_activation_output;
+
     /* Total number of weights, and size of weights buffer. */
     int total_weights;
 
@@ -97,6 +102,7 @@ void genann_write(genann const *ann, FILE *out);
 void genann_init_sigmoid_lookup(const genann *ann);
 double genann_act_sigmoid(const genann *ann, double a);
 double genann_act_sigmoid_cached(const genann *ann, double a);
+double genann_act_diffexpr_sigmoid(const genann *ann, double y);
 double genann_act_threshold(const genann *ann, double a);
 double genann_act_linear(const genann *ann, double a);
 


### PR DESCRIPTION
This simple change would half address issue #31 . It generalises the training procedure for the sigmoid to other invertible functions.
It doesn't work for most non-invertible activation functions.[a] Those could be addressed by a different training procedure which would require the weighted sum input to a node instead of just the resulting value, and would use the derivative proper instead of a "differential expression" in terms of the function value. I might implement this at some point, but it would be more of a hassle.
[a] one exception is ReLU, which is non-invertible as it has the same value for all negative inputs; it just so happens that the derivative also has the same value for all of those inputs.

I am unhappy with the naming - "differential expression" was the best I could come up with, hopefully someone knows a better term for this.

If there are any adjustments I need to make, please let me know.