### PR TITLE
fix missing dependecies in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS = -Wall -Wshadow -O3 -g -march=native
+CFLAGS = -Wall -Wshadow -O3 -g -march=native -MMD
 LDLIBS = -lm
 
 all: check example1 example2 example3 example4
@@ -25,10 +25,11 @@ example3: example3.o genann.o
 
 example4: example4.o genann.o
 
-
 clean:
-	$(RM) *.o
+	$(RM) *.o *.d
 	$(RM) test example1 example2 example3 example4 *.exe
 	$(RM) persist.txt
 
 .PHONY: sigmoid threshold linear clean
+
+-include $(wildcard *.d)


### PR DESCRIPTION
This PR fixes an issue in the Makefile. Specifically, previously, any modifications of files like genann.h would not trigger a rebuild of genann.o. The PR fixes this by including them as additional dependencies.